### PR TITLE
Change to HTTP url from SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docs = [
 ]
 
 for ((remote, branch), docref) in docs
-    run(`git clone --depth 1 git@github.com:$remote --branch $branch --single-branch $(docref.upstream)`)
+    run(`git clone --depth 1 https://github.com/$remote --branch $branch --single-branch $(docref.upstream)`)
 end
 
 outpath = joinpath(@__DIR__, "out")


### PR DESCRIPTION
This seems to cause trouble with rights 

```
Please make sure you have the correct access rights
and the repository exists.
ERROR: LoadError: failed process: Process(`git clone --depth 1 git@github.com:GenieFramework/Stipple.jl.git --branch master --single-branch /var/folders/0j/d0xd373d2tb7zdzcsqrk3mpw0000gn/T/jl_ri4lRM/Stipple`, ProcessExited(128)) [128]
```