### PR TITLE
README: In the example, demonstrate how to use SSH for some repos and HTTPS for other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docs = [
     ),
 ]
 
-for ((remote, branch, prefix), docref) in docs
+for ((remote, branch, use_ssh), docref) in docs
     prefix = use_ssh ? "git@github.com:" : "https://github.com/"
     run(`git clone --depth 1 $prefix$remote --branch $branch --single-branch $(docref.upstream)`)
 end

--- a/README.md
+++ b/README.md
@@ -9,24 +9,23 @@ using MultiDocumenter
 clonedir = mktempdir()
 
 docs = [
-    ("JuliaDocs/Documenter.jl.git", "gh-pages") => MultiDocumenter.MultiDocRef(
+    ("JuliaDocs/Documenter.jl.git", "gh-pages", false) => MultiDocumenter.MultiDocRef(
         upstream = joinpath(clonedir, "Documenter"),
         path = "doc",
         name = "Documenter"
     ),
-    ("JuliaDebug/Infiltrator.jl.git", "gh-pages") => MultiDocumenter.MultiDocRef(
+    # using SSH for cloning is suggested when you're dealing with private repos, because
+    # an ssh-agent will handle your keys for you
+    # ("JuliaDebug/Infiltrator.jl.git", "gh-pages", true) => MultiDocumenter.MultiDocRef(
+    ("JuliaDebug/Infiltrator.jl.git", "gh-pages", false) => MultiDocumenter.MultiDocRef(
         upstream = joinpath(clonedir, "Infiltrator"),
         path = "inf",
         name = "Infiltrator"
     ),
 ]
 
-# using SSH for cloning is suggested when you're dealing with private repos, because
-# an ssh-agent will handle your keys for you
-# prefix = "git@github.com:"
-prefix = "https://github.com/"
-
-for ((remote, branch), docref) in docs
+for ((remote, branch, prefix), docref) in docs
+    prefix = use_ssh ? "git@github.com:" : "https://github.com/"
     run(`git clone --depth 1 $prefix$remote --branch $branch --single-branch $(docref.upstream)`)
 end
 


### PR DESCRIPTION
I can imagine a situation where people have some public packages and some private packages. For each of their private packages, they set up a read-only deploy key, and they add each of those deploy keys to their SSH agent. (On CI, they might use the [`webfactory/ssh-agent`](https://github.com/webfactory/ssh-agent) action.) For the public repos, there isn't any need to set up deploy keys. So you'd want to use SSH for the private repos and HTTPs for the public repos.

This PR updates the example in the README to show how you might specify which repos should be cloned over SSH and which repos should be cloned over HTTPS.