### PR TITLE
Fix for #39

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiDocumenter"
 uuid = "87ed4bf0-c935-4a67-83c3-2a03bee4197c"
 authors = ["Sebastian Pfitzner <pfitzseb@gmail.com> and contributors"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/search/flexsearch.jl
+++ b/src/search/flexsearch.jl
@@ -94,8 +94,8 @@ function generate_index(root, docs, config)
 end
 
 function inject_script!(custom_scripts)
-    pushfirst!(custom_scripts, joinpath("assets", "default", "flexsearch.bundle.js"))
     pushfirst!(custom_scripts, joinpath("assets", "default", "flexsearch_integration.js"))
+    pushfirst!(custom_scripts, joinpath("assets", "default", "flexsearch.bundle.js"))
 end
 
 function inject_styles!(custom_styles)


### PR DESCRIPTION
FlexSearch should be loaded before the integration script is loaded; this PR changes the ordering accordingly, thus fixing #39.