### PR TITLE
Fix for #36

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiDocumenter"
 uuid = "87ed4bf0-c935-4a67-83c3-2a03bee4197c"
 authors = ["Sebastian Pfitzner <pfitzseb@gmail.com> and contributors"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/assets/default/flexsearch_integration.js
+++ b/assets/default/flexsearch_integration.js
@@ -22,7 +22,7 @@
         const keys = ['content.cfg', 'content.ctx', 'content.map', 'reg', 'store']
         const promises = keys.map(key => {
             return new Promise((resolve, reject) => {
-                fetch('/search-data/' + key + '.json').then(r => {
+                fetch('../../search-data/' + key + '.json').then(r => {
                     if (r && r.ok) {
                         r.json().then(idx => {
                             flexsearchIdx.import(key, idx)


### PR DESCRIPTION
Now fetches the FlexSearch related files from a relative path instead of absolute path.

EDIT: Nvm this breaks when you access a sub-page of a given doc :facepalm: Seems like it just needs to be made configurable.