### PR TITLE
Use Git.jl/Git_jll for cloning repos

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.5.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 Gumbo = "708ec375-b3d6-5a57-a7ce-8257bf98657a"
 HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -13,6 +14,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 AbstractTrees = "0.4"
+Git = "1"
 Gumbo = "0.8.2"
 HypertextLiteral = "0.9"
 JSON = "0.20,0.21"

--- a/src/MultiDocumenter.jl
+++ b/src/MultiDocumenter.jl
@@ -2,6 +2,7 @@ module MultiDocumenter
 
 import Gumbo, AbstractTrees
 using HypertextLiteral
+import Git: git
 
 """
     SearchConfig(index_versions = ["stable"], engine = MultiDocumenter.FlexSearch, lowfi = false)
@@ -170,7 +171,9 @@ function maybe_clone(docs::Vector{MultiDocRef})
     for doc in docs
         if !isdir(doc.upstream)
             @info "Upstream at $(doc.upstream) does not exist. `git clone`ing `$(doc.giturl)#$(doc.branch)`"
-            run(`git clone --depth 1 $(doc.giturl) --branch $(doc.branch) --single-branch $(doc.upstream)`)
+            run(
+                `$(git()) clone --depth 1 $(doc.giturl) --branch $(doc.branch) --single-branch $(doc.upstream)`,
+            )
         end
     end
 end


### PR DESCRIPTION
Mainly so that you wouldn't be at the mercy of the Git version available on your system. Although, maybe this is something that should be configurable?