### PR TITLE
Guard Git commands in `docs/make.jl` against accidental deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,4 +27,4 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          julia --project=. docs/make.jl
+          julia --project=. docs/make.jl deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+/docs/out/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -81,33 +81,39 @@ MultiDocumenter.make(
     rootpath = "/MultiDocumenter.jl/",
 )
 
-gitroot = normpath(joinpath(@__DIR__, ".."))
-run(`git pull`)
-outbranch = "gh-pages"
-has_outbranch = true
-if !success(`git checkout $outbranch`)
-    has_outbranch = false
-    if !success(`git switch --orphan $outbranch`)
-        @error "Cannot create new orphaned branch $outbranch."
-        exit(1)
+if "deploy" in ARGS
+    @warn "Deploying to GitHub" ARGS
+    gitroot = normpath(joinpath(@__DIR__, ".."))
+    run(`git pull`)
+    outbranch = "gh-pages"
+    has_outbranch = true
+    if !success(`git checkout $outbranch`)
+        has_outbranch = false
+        if !success(`git switch --orphan $outbranch`)
+            @error "Cannot create new orphaned branch $outbranch."
+            exit(1)
+        end
     end
-end
-for file in readdir(gitroot; join = true)
-    endswith(file, ".git") && continue
-    rm(file; force = true, recursive = true)
-end
-for file in readdir(outpath)
-    cp(joinpath(outpath, file), joinpath(gitroot, file))
-end
-run(`git add .`)
-if success(`git commit -m 'Aggregate documentation'`)
-    @info "Pushing updated documentation."
-    if has_outbranch
-        run(`git push`)
+    for file in readdir(gitroot; join = true)
+        endswith(file, ".git") && continue
+        rm(file; force = true, recursive = true)
+    end
+    for file in readdir(outpath)
+        cp(joinpath(outpath, file), joinpath(gitroot, file))
+    end
+    run(`git add .`)
+    if success(`git commit -m 'Aggregate documentation'`)
+        @info "Pushing updated documentation."
+        if has_outbranch
+            run(`git push`)
+        else
+            run(`git push -u origin $outbranch`)
+        end
+        run(`git checkout main`)
     else
-        run(`git push -u origin $outbranch`)
+        @info "No changes to aggregated documentation."
     end
-    run(`git checkout main`)
 else
-    @info "No changes to aggregated documentation."
+    @info "Skipping deployment, 'deploy' not passed. Generated files in docs/out." ARGS
+    cp(outpath, joinpath(@__DIR__, "out"))
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -115,5 +115,5 @@ if "deploy" in ARGS
     end
 else
     @info "Skipping deployment, 'deploy' not passed. Generated files in docs/out." ARGS
-    cp(outpath, joinpath(@__DIR__, "out"), force=true)
+    cp(outpath, joinpath(@__DIR__, "out"), force = true)
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -115,5 +115,5 @@ if "deploy" in ARGS
     end
 else
     @info "Skipping deployment, 'deploy' not passed. Generated files in docs/out." ARGS
-    cp(outpath, joinpath(@__DIR__, "out"))
+    cp(outpath, joinpath(@__DIR__, "out"), force=true)
 end


### PR DESCRIPTION
So you have to pass an explicit `deploy` command line argument to actually invoke Git. Since it actually seems to `git push` if there are any changes, this seems like a potential footgun. I just wanted to quickly just build the example doc locally to test something.