### PR TITLE
Add option to generate a sitemap

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -79,6 +79,8 @@ MultiDocumenter.make(
         engine = MultiDocumenter.FlexSearch,
     ),
     rootpath = "/MultiDocumenter.jl/",
+    canonical_domain = "https://juliacomputing.github.io/",
+    sitemap = true,
 )
 
 if "deploy" in ARGS

--- a/src/documentertools/canonical_urls.jl
+++ b/src/documentertools/canonical_urls.jl
@@ -135,8 +135,10 @@ end
 Parses the HTML file at `indexhtml_path` and tries to extract the `url=...` value
 of the redirect `<meta http-equiv="refresh" ...>` tag.
 """
-function get_meta_redirect_url(indexhtml_path::AbstractString)
-    html = Gumbo.parsehtml(read(indexhtml_path, String))
+get_meta_redirect_url(indexhtml_path::AbstractString) =
+    get_meta_redirect_url(Gumbo.parsehtml(read(indexhtml_path, String)))
+
+function get_meta_redirect_url(html::Gumbo.HTMLDocument)
     for e in AbstractTrees.PreOrderDFS(html.root)
         e isa Gumbo.HTMLElement || continue
         Gumbo.tag(e) == :meta || continue

--- a/src/sitemap.jl
+++ b/src/sitemap.jl
@@ -1,0 +1,104 @@
+# Note: Franklin.jl also implements sitemap generation:
+#
+#   https://github.com/tlienart/Franklin.jl/blob/f1f7d044dc95ba0d9f368a3d1afc233eb58a59cf/src/manager/sitemap_generator.jl#L51
+#
+# At some point it might be worth factoring the code into a small shared package.
+# Franklin's implementation is more general that this here, but it looks like it relies
+# of Franklin-specific globals, so it's not a trivial copy-paste into a separate package.
+
+const SITEMAP_URL_LIMIT = 50_000
+const SITEMAP_SIZE_LIMIT = 52_428_800
+
+function make_sitemap(;
+    sitemap_filename::AbstractString,
+    sitemap_root::AbstractString,
+    docs_root_directory::AbstractString,
+)
+    # Determine the list of sitemap URLs by finding all canonical URLs
+    sitemap_urls = find_sitemap_urls(; docs_root_directory, sitemap_root)
+    if length(sitemap_urls) == 0
+        @error "No sitemap URLs found"
+        return
+    end
+
+    sitemap_buffer = IOBuffer()
+    write(
+        sitemap_buffer,
+        """
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+""",
+    )
+    for loc in sort(sitemap_urls)
+        write(sitemap_buffer, "<url><loc>$(loc)</loc></url>\n")
+    end
+    write(sitemap_buffer, "</urlset>\n")
+
+    # Sitemaps are limited to 50 000 URLs: https://www.sitemaps.org/protocol.html#index
+    # TODO: we could automatically split the sitemap up if it's bigger than that and
+    # generate a sitemap index.
+    if length(sitemap_urls) > SITEMAP_URL_LIMIT
+        @warn "Sitemap file has too many items: $(length(canonical_urls)) (limit: $(SITEMAP_URL_LIMIT))"
+    end
+    sitemap_bytes = take!(sitemap_buffer)
+    if length(sitemap_bytes) > SITEMAP_SIZE_LIMIT
+        @warn "Sitemap is too large: $(length(sitemap_bytes)) bytes (limit: $(SITEMAP_SIZE_LIMIT))"
+    end
+
+    # Write the actual sitemap.xml file into the output directory
+    write(joinpath(docs_root_directory, sitemap_filename), sitemap_bytes)
+end
+
+function find_sitemap_urls(;
+    docs_root_directory::AbstractString,
+    sitemap_root::AbstractString,
+)
+    # On Windows, .relpath should have \ as path separators, which we have to
+    # "normalize" to /-s for web
+    canonical_urls = String[]
+    DocumenterTools.walkdocs(docs_root_directory, DocumenterTools.isdochtml) do fileinfo
+        html = Gumbo.parsehtml(read(fileinfo.fullpath, String))
+        canonical_href = find_canonical_url(html; filepath = fileinfo.fullpath)
+        if isnothing(canonical_href)
+            # A common case for why the canonical URL would be missing is when it's a redirect
+            # HTML file, and that is fine. So we check for that and only warn if it is _not_
+            # a redirect file.
+            if DocumenterTools.get_meta_redirect_url(html) === nothing
+                @warn "Canonical URL missing: $(fileinfo.relpath)"
+            end
+            return
+        end
+        # Check that the canonincal URL is correct.
+        # First, we check that the root part is actually what we expect it to be.
+        if !startswith(canonical_href, sitemap_root)
+            @warn "Invalid canonical URL, excluded from sitemap." canonical_href fileinfo.fullpath
+            return
+        end
+        # Let's make sure we're not adding duplicates, but first we must normalize the URL
+        canonical_href = normalize_canonical_url(canonical_href)
+        if !(canonical_href in canonical_urls)
+            push!(canonical_urls, canonical_href)
+        end
+    end
+    return canonical_urls
+end
+
+# foo/bar, foo/bar/ and foo/bar/index.html are basically equivalent, so we normalize the canonical
+# URL to foo/bar/
+normalize_canonical_url(url::AbstractString) = replace(url, r"/(index\.html)?$" => "/")
+
+# Loops through a Gumbo-parsed DOM tree
+function find_canonical_url(html::Gumbo.HTMLDocument; filepath::AbstractString)
+    canonical_href = nothing
+    for e in AbstractTrees.PreOrderDFS(html.root)
+        e isa Gumbo.HTMLElement || continue
+        Gumbo.tag(e) == :link || continue
+        Gumbo.getattr(e, "rel", nothing) == "canonical" || continue
+        if isnothing(canonical_href)
+            canonical_href = Gumbo.getattr(e, "href", nothing)
+        else
+            @warn "Duplicate <link rel=\"canonical\" ...> tag. Ignoring." filepath e canonical_href
+        end
+    end
+    return canonical_href
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,104 +1,108 @@
 using MultiDocumenter
 using Test
 
-@testset "MultiDocumenter.jl" begin
-    @testset "DocumenterTools vendored helpers" begin
-        include("documentertools.jl")
-    end
+@testset "DocumenterTools vendored helpers" begin
+    include("documentertools.jl")
+end
 
-    clonedir = mktempdir()
-
-    docs = [
-        MultiDocumenter.DropdownNav(
-            "Debugging",
-            [
-                MultiDocumenter.MultiDocRef(
-                    upstream = joinpath(clonedir, "Infiltrator"),
-                    path = "inf",
-                    name = "Infiltrator",
-                    giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
-                ),
-                MultiDocumenter.MultiDocRef(
-                    upstream = joinpath(clonedir, "JuliaInterpreter"),
-                    path = "debug",
-                    name = "JuliaInterpreter",
-                    giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
-                ),
-            ],
-        ),
-        MultiDocumenter.MegaDropdownNav(
-            "Mega Debugger",
-            [
-                MultiDocumenter.Column(
-                    "Column 1",
-                    [
-                        MultiDocumenter.MultiDocRef(
-                            upstream = joinpath(clonedir, "Infiltrator"),
-                            path = "inf",
-                            name = "Infiltrator",
-                            giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
-                        ),
-                        MultiDocumenter.MultiDocRef(
-                            upstream = joinpath(clonedir, "JuliaInterpreter"),
-                            path = "debug",
-                            name = "JuliaInterpreter",
-                            giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
-                        ),
-                        MultiDocumenter.MultiDocRef(
-                            upstream = joinpath(clonedir, "Lux"),
-                            path = "lux",
-                            name = "Lux",
-                            giturl = "https://github.com/avik-pal/Lux.jl",
-                        ),
-                    ],
-                ),
-                MultiDocumenter.Column(
-                    "Column 2",
-                    [
-                        MultiDocumenter.MultiDocRef(
-                            upstream = joinpath(clonedir, "Infiltrator"),
-                            path = "inf",
-                            name = "Infiltrator",
-                            giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
-                        ),
-                        MultiDocumenter.MultiDocRef(
-                            upstream = joinpath(clonedir, "JuliaInterpreter"),
-                            path = "debug",
-                            name = "JuliaInterpreter",
-                            giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        MultiDocumenter.MultiDocRef(
-            upstream = joinpath(clonedir, "DataSets"),
-            path = "data",
-            name = "DataSets",
-            giturl = "https://github.com/JuliaComputing/DataSets.jl.git",
-            # or use ssh instead for private repos:
-            # giturl = "git@github.com:JuliaComputing/DataSets.jl.git",
-        ),
-    ]
-
-    outpath = joinpath(@__DIR__, "out")
-
-    rootpath = "/MultiDocumenter.jl/"
-
-    MultiDocumenter.make(
-        outpath,
-        docs;
-        search_engine = MultiDocumenter.SearchConfig(
-            index_versions = ["stable", "dev"],
-            engine = MultiDocumenter.FlexSearch,
-        ),
-        custom_scripts = [
-            "foo/bar.js",
-            "https://foo.com/bar.js",
-            Docs.HTML("const foo = 'bar';"),
+clonedir = mktempdir()
+outpath = joinpath(@__DIR__, "out")
+rootpath = "/MultiDocumenter.jl/"
+atexit() do
+    rm(outpath, recursive = true, force = true)
+    rm(clonedir, recursive = true, force = true)
+end
+docs = [
+    MultiDocumenter.DropdownNav(
+        "Debugging",
+        [
+            MultiDocumenter.MultiDocRef(
+                upstream = joinpath(clonedir, "Infiltrator"),
+                path = "inf",
+                name = "Infiltrator",
+                giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
+            ),
+            MultiDocumenter.MultiDocRef(
+                upstream = joinpath(clonedir, "JuliaInterpreter"),
+                path = "debug",
+                name = "JuliaInterpreter",
+                giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
+            ),
         ],
-        rootpath = rootpath,
-    )
+    ),
+    MultiDocumenter.MegaDropdownNav(
+        "Mega Debugger",
+        [
+            MultiDocumenter.Column(
+                "Column 1",
+                [
+                    MultiDocumenter.MultiDocRef(
+                        upstream = joinpath(clonedir, "Infiltrator"),
+                        path = "inf",
+                        name = "Infiltrator",
+                        giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
+                    ),
+                    MultiDocumenter.MultiDocRef(
+                        upstream = joinpath(clonedir, "JuliaInterpreter"),
+                        path = "debug",
+                        name = "JuliaInterpreter",
+                        giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
+                    ),
+                    MultiDocumenter.MultiDocRef(
+                        upstream = joinpath(clonedir, "Lux"),
+                        path = "lux",
+                        name = "Lux",
+                        giturl = "https://github.com/avik-pal/Lux.jl",
+                    ),
+                ],
+            ),
+            MultiDocumenter.Column(
+                "Column 2",
+                [
+                    MultiDocumenter.MultiDocRef(
+                        upstream = joinpath(clonedir, "Infiltrator"),
+                        path = "inf",
+                        name = "Infiltrator",
+                        giturl = "https://github.com/JuliaDebug/Infiltrator.jl.git",
+                    ),
+                    MultiDocumenter.MultiDocRef(
+                        upstream = joinpath(clonedir, "JuliaInterpreter"),
+                        path = "debug",
+                        name = "JuliaInterpreter",
+                        giturl = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git",
+                    ),
+                ],
+            ),
+        ],
+    ),
+    MultiDocumenter.MultiDocRef(
+        upstream = joinpath(clonedir, "DataSets"),
+        path = "data",
+        name = "DataSets",
+        giturl = "https://github.com/JuliaComputing/DataSets.jl.git",
+        # or use ssh instead for private repos:
+        # giturl = "git@github.com:JuliaComputing/DataSets.jl.git",
+    ),
+]
+MultiDocumenter.make(
+    outpath,
+    docs;
+    search_engine = MultiDocumenter.SearchConfig(
+        index_versions = ["stable", "dev"],
+        engine = MultiDocumenter.FlexSearch,
+    ),
+    custom_scripts = [
+        "foo/bar.js",
+        "https://foo.com/bar.js",
+        Docs.HTML("const foo = 'bar';"),
+    ],
+    rootpath = rootpath,
+    canonical_domain = "https://example.org/",
+    sitemap = true,
+    sitemap_filename = "sitemap-mydocs.xml",
+)
+
+@testset "MultiDocumenter.jl" begin
 
     @testset "structure" begin
         @test isdir(outpath, "inf")
@@ -110,6 +114,10 @@ using Test
         <!--This file is automatically generated by Documenter.jl-->
         <meta http-equiv="refresh" content="0; url=./stable/"/>
         """
+
+        # We override the sitemap filename
+        @test !isfile(joinpath(outpath, "sitemap.xml"))
+        @test isfile(joinpath(outpath, "sitemap-mydocs.xml"))
     end
 
 
@@ -134,6 +142,16 @@ using Test
         )
     end
 
+    @testset "canonical URLs" begin
+        index = read(joinpath(outpath, "inf", "stable", "index.html"), String)
+        canonical_href = "<link href=\"https://example.org/MultiDocumenter.jl/inf/stable/\" rel=\"canonical\"/>"
+        @test occursin(canonical_href, index)
+
+        index = read(joinpath(outpath, "inf", "v1.6.0", "index.html"), String)
+        canonical_href = "<link href=\"https://example.org/MultiDocumenter.jl/inf/stable/\" rel=\"canonical\"/>"
+        @test occursin(canonical_href, index)
+    end
+
     @testset "flexsearch" begin
         @test isdir(outpath, "search-data")
         store_content = read(joinpath(outpath, "search-data", "store.json"), String)
@@ -145,6 +163,86 @@ using Test
         @test !occursin("/inf/dev/", store_content)
     end
 
-    rm(outpath, recursive = true, force = true)
-    rm(clonedir, recursive = true, force = true)
+    @testset "sitemap" begin
+        @testset "normalize_canonical_url" begin
+            @test MultiDocumenter.normalize_canonical_url("") == ""
+            @test MultiDocumenter.normalize_canonical_url("/") == "/"
+            @test MultiDocumenter.normalize_canonical_url("//") == "//"
+            @test MultiDocumenter.normalize_canonical_url("foo") == "foo"
+            @test MultiDocumenter.normalize_canonical_url("foo/") == "foo/"
+            @test MultiDocumenter.normalize_canonical_url("foo//") == "foo//"
+            @test MultiDocumenter.normalize_canonical_url("foo/bar") == "foo/bar"
+            @test MultiDocumenter.normalize_canonical_url("foo/bar/") == "foo/bar/"
+            @test MultiDocumenter.normalize_canonical_url("foo/bar//") == "foo/bar//"
+            @test MultiDocumenter.normalize_canonical_url("foo//bar") == "foo//bar"
+            @test MultiDocumenter.normalize_canonical_url("foo.html") == "foo.html"
+            @test MultiDocumenter.normalize_canonical_url("/foo.html") == "/foo.html"
+            @test MultiDocumenter.normalize_canonical_url("/foo/bar.html") ==
+                  "/foo/bar.html"
+            @test MultiDocumenter.normalize_canonical_url("/foo.html/") == "/foo.html/"
+            @test MultiDocumenter.normalize_canonical_url("/index.html") == "/"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html") == "/foo/"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html") == "/foo/"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html/") ==
+                  "/foo/index.html/"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html/bar") ==
+                  "/foo/index.html/bar"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html/bar/") ==
+                  "/foo/index.html/bar/"
+            @test MultiDocumenter.normalize_canonical_url("/foo/index.html/bar/baz.html") ==
+                  "/foo/index.html/bar/baz.html"
+            @test MultiDocumenter.normalize_canonical_url(
+                "/foo/index.html/bar/index.html",
+            ) == "/foo/index.html/bar/"
+            # Full URL test cases
+            @test MultiDocumenter.normalize_canonical_url("https://example.org") ==
+                  "https://example.org"
+            @test MultiDocumenter.normalize_canonical_url("https://example.org/") ==
+                  "https://example.org/"
+            @test MultiDocumenter.normalize_canonical_url("https://example.org/foo.html") ==
+                  "https://example.org/foo.html"
+            @test MultiDocumenter.normalize_canonical_url(
+                "https://example.org/index.html",
+            ) == "https://example.org/"
+            @test MultiDocumenter.normalize_canonical_url("https://example.org/foo") ==
+                  "https://example.org/foo"
+            @test MultiDocumenter.normalize_canonical_url("https://example.org/foo/") ==
+                  "https://example.org/foo/"
+            @test MultiDocumenter.normalize_canonical_url(
+                "https://example.org/foo/index.html",
+            ) == "https://example.org/foo/"
+            @test MultiDocumenter.normalize_canonical_url(
+                "https://example.org/foo/bar.html",
+            ) == "https://example.org/foo/bar.html"
+            # Edge case that should maybe be "/", but not worth having a special case for
+            @test MultiDocumenter.normalize_canonical_url("index.html") == "index.html"
+        end
+
+        sitemap_content = read(joinpath(outpath, "sitemap-mydocs.xml"), String)
+        @test occursin(
+            "https://example.org/MultiDocumenter.jl/inf/stable/",
+            sitemap_content,
+        )
+        @test occursin(
+            "https://example.org/MultiDocumenter.jl/debug/stable/",
+            sitemap_content,
+        )
+        @test occursin(
+            "https://example.org/MultiDocumenter.jl/inf/stable/API/",
+            sitemap_content,
+        )
+        @test !occursin(
+            "https://example.org/MultiDocumenter.jl/inf/v1/API/",
+            sitemap_content,
+        )
+        @test !occursin(
+            "https://example.org/MultiDocumenter.jl/inf/v1.6/API/",
+            sitemap_content,
+        )
+        @test !occursin(
+            "https://example.org/MultiDocumenter.jl/inf/v1.6.0/API/",
+            sitemap_content,
+        )
+    end
+
 end


### PR DESCRIPTION
Just wanted to open a draft PR here with this naive implementation, which takes all the HTML files and generates the sitemap with all of them.

However, I realized that this way we'll end up with all the old versions also in the sitemap, and I [don't this that's a good idea, since sitemaps should also point to canonical content](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#sitemap-method). So we need to be a bit smarter about it.

We could try to interpret the file system paths, but I figured a better way is to re-use canonical URLs, which we can parse from the HTML. The sitemap will be just the canonical URLs, but we'll also make sure that the canonical URL is reasonable. HTML files with missing or broken canonical URLs get ignored.

This pushes the responsibility of having good canonical URLs to the HTML generation. So I think we want a post-processing step here as well for each subpage, to catch and/or fix bad or missing canonical URLs.

