### PR TITLE
feat: use all .html files when generating search indexes

### DIFF
--- a/src/MultiDocumenter.jl
+++ b/src/MultiDocumenter.jl
@@ -75,10 +75,7 @@ function walk_outputs(f, root, docs::Vector{MultiDocRef}, dirs::Vector{String})
         for dir in dirs
             dirpath = joinpath(p, dir)
             isdir(dirpath) || continue
-            DocumenterTools.walkdocs(
-                dirpath,
-                fileinfo -> fileinfo.filename == "index.html",
-            ) do fileinfo
+            DocumenterTools.walkdocs(dirpath, DocumenterTools.isdochtml) do fileinfo
                 f(relpath(dirname(fileinfo.fullpath), root), fileinfo.fullpath)
             end
             break


### PR DESCRIPTION
Rather than just the ones called `index.html`. Shouldn't affect most sites much, since generally they have pretty URLs enabled. But it would add support for sites that choose to not use it for one reason or another.