### PR TITLE
Add --temp option to docs/make.jl, use docs/clones by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
 /docs/out/
+/docs/clones/

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,19 @@
+# Script to build the MultiDocumenter demo docs
+#
+#   julia --project docs/make.jl [--temp] [deploy]
+#
+# When `deploy` is passed as an argument, it goes into deployment mode
+# and attempts to push the generated site to gh-pages. You can also pass
+# `--temp`, in which case the source repositories are cloned into a temporary
+# directory (as opposed to `docs/clones`).
 using MultiDocumenter
 
-clonedir = mktempdir()
+clonedir = ("--temp" in ARGS) ? mktempdir() : joinpath(@__DIR__, "clones")
+outpath = mktempdir()
+@info """
+Cloning packages into: $(clonedir)
+Building aggregate site into: $(outpath)
+"""
 
 docs = [
     MultiDocumenter.DropdownNav(
@@ -68,8 +81,6 @@ docs = [
         # giturl = "git@github.com:JuliaComputing/DataSets.jl.git",
     ),
 ]
-
-outpath = mktempdir()
 
 MultiDocumenter.make(
     outpath,


### PR DESCRIPTION
Useful when locally building the MultiDocumenter docs.