### PR TITLE
Allow for non-string names

### DIFF
--- a/assets/default/flexsearch_integration.js
+++ b/assets/default/flexsearch_integration.js
@@ -41,7 +41,7 @@
         })
 
         Promise.all(promises).then(() => {
-            input.setAttribute('placeholder', 'Search...')
+            input.setAttribute('placeholder', 'Search everywhere...')
             successfullyLoadedIndex = true
         }).catch(() => {
             input.setAttribute('placeholder', 'Error loading search data...')

--- a/src/MultiDocumenter.jl
+++ b/src/MultiDocumenter.jl
@@ -47,7 +47,7 @@ Represents one set of docs that will get an entry in the MultiDocumenter navigat
 struct MultiDocRef
     upstream::String
     path::String
-    name::String
+    name::Any
     fix_canonical_url::Bool
     giturl::String
     branch::String

--- a/src/search/flexsearch.jl
+++ b/src/search/flexsearch.jl
@@ -110,7 +110,7 @@ end
 function render()
     return @htl """
     <div class="search nav-item">
-        <input id="search-input" placeholder="Search...">
+        <input id="search-input" placeholder="Search everywhere...">
         <ul id="search-result-container" class="suggestions hidden">
         </ul>
         <div class="search-keybinding">/</div>

--- a/src/search/stork.jl
+++ b/src/search/stork.jl
@@ -73,7 +73,7 @@ end
 function render()
     return @htl """
     <div class="search nav-item stork-wrapper">
-        <input id="search-input" class="stork-input" data-stork="multidocumenter" placeholder="Search...">
+        <input id="search-input" class="stork-input" data-stork="multidocumenter" placeholder="Search everywhere..">
         <div data-stork="multidocumenter-output" class="stork-output"></div>
         <div class="search-keybinding">/</div>
     </div>


### PR DESCRIPTION
I want to splice some CSS into my header, but a `string` doesnt allow this, as it escapes all html/css and I need to use a `@htl "<br>my_string"` thingy.

This allowed me (with some CSS hacks) to do:
![grafik](https://github.com/user-attachments/assets/25089d28-4c2f-4ee3-9f22-02f77b6c6476)

edit: urgh, sorry the #83 is also included in this PR but should be separate. If this is something you are interested, I'll redo this PR with a clean commit history
