### PR TITLE
fix: use correct font for flexsearch input

### DIFF
--- a/assets/default/flexsearch.css
+++ b/assets/default/flexsearch.css
@@ -20,7 +20,7 @@
     color: #999;
     background-color: unset;
     height: 28px;
-    font-family: Glober;
+    font-family: inherit;
     width: 20em;
     font-size: 14px;
     padding: 0 8px;


### PR DESCRIPTION
Fixes https://github.com/JuliaComputing/MultiDocumenter.jl/issues/56.